### PR TITLE
removed props from the dependency array

### DIFF
--- a/src/components/Checkout.tsx
+++ b/src/components/Checkout.tsx
@@ -23,8 +23,7 @@ const SafepayCheckout: React.FC<SafepayCheckoutProps> = (
 
   const [modalVisible, setModalVisible] = useState(false);
   const [token, setToken] = useState('');
-  useEffect(() => {
-    const fetchToken = async () => {
+   const fetchToken = async () => {
       try {
         const response = await fetch(`${baseURL}order/v1/init`, {
           method: 'POST',
@@ -46,6 +45,8 @@ const SafepayCheckout: React.FC<SafepayCheckoutProps> = (
         console.error(error);
       }
     };
+    
+    useEffect(() => {
     if (modalVisible) {
       fetchToken();
     }

--- a/src/components/Checkout.tsx
+++ b/src/components/Checkout.tsx
@@ -49,7 +49,7 @@ const SafepayCheckout: React.FC<SafepayCheckoutProps> = (
     if (modalVisible) {
       fetchToken();
     }
-  }, [modalVisible, props]);
+  }, [modalVisible]);
 
   const params = {
     beacon: `${token}`,


### PR DESCRIPTION
Issue:
The webview keeps refreshing itself on the checkout page every few seconds. If the user is entering bank details and a refresh happens, consequently all the form data is lost and it fetches the payment methods again

Solution:
Remove props from the dependency array of useEffect, but there was no need. Even if any of the props are required to be put in dependency array we can destruct it and use it then.
